### PR TITLE
compatibility with 2.5 is missing a with_statement in logbook._fallback

### DIFF
--- a/logbook/_fallback.py
+++ b/logbook/_fallback.py
@@ -8,6 +8,8 @@
     :copyright: (c) 2010 by Armin Ronacher, Georg Brandl.
     :license: BSD, see LICENSE for more details.
 """
+from __future__ import with_statement
+
 import threading
 from itertools import count
 from thread import get_ident as current_thread


### PR DESCRIPTION
flox on IRC noted this
