### PR TITLE
Have the ThreadedWrapperHandler use 'handle' and not 'emit'

### DIFF
--- a/logbook/queues.py
+++ b/logbook/queues.py
@@ -359,7 +359,7 @@ class TWHThreadController(object):
             if record is self._sentinel:
                 self.running = False
                 break
-            self.wrapper_handler.handler.emit(record)
+            self.wrapper_handler.handler.handle(record)
 
 
 class ThreadedWrapperHandler(WrapperHandler):


### PR DESCRIPTION
Handler.handle catches exceptions while Handler.emit does not.

If a logger raises an exception when being ran under ThreadedWrapperHandler you will get a

```
Exception in thread Thread-1:
```

and the thread will die.  Additionally this can likely cause memory issues as the shared queue will grow indefinitely.
