### PR TITLE
Unable to run mailhandler with default settings

### DIFF
--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -1121,7 +1121,7 @@ class MailHandler(Handler, StringFormatterHandlerMixin,
         """
         from smtplib import SMTP, SMTP_PORT, SMTP_SSL_PORT
         if self.server_addr is None:
-            host = ''
+            host = 'localhost'
             port = self.secure and SMTP_SSL_PORT or SMTP_PORT
         else:
             host, port = self.server_addr


### PR DESCRIPTION
Hi Misuhiko,

I have the following code snippet:

<pre>
 #!/usr/bin/env python

 import logbook

 handler = logbook.MailHandler("someone@example.com", ['other@example.com'],
                              format_string=logbook.handlers.MAIL_FORMAT_STRING, level='INFO', bubble = True)

 log = logbook.Logger("mailtest.log")

 with handler.applicationbound():
         log.info("Hello world")
</pre>


Without defaulting to localhost, I get this traceback:

<pre>
 $ python mailtest.py
 Traceback (most recent call last):
  File ".virtualenvs/production/lib/python2.6/site-packages/logbook/handlers.py", line 214, in handle
    self.emit(record)
  File ".virtualenvs/production/lib/python2.6/site-packages/logbook/handlers.py", line 1163, in emit
    self.get_recipients(record))
  File ".virtualenvs/production/lib/python2.6/site-packages/logbook/handlers.py", line 1150, in deliver
    con = self.get_connection()
  File ".virtualenvs/production/lib/python2.6/site-packages/logbook/handlers.py", line 1129, in get_connection
    con.connect(host, port)
  File "/usr/lib64/python2.6/smtplib.py", line 295, in connect
    self.sock = self._get_socket(host, port, self.timeout)
  File "/usr/lib64/python2.6/smtplib.py", line 273, in _get_socket
    return socket.create_connection((port, host), timeout)
  File "/usr/lib64/python2.6/socket.py", line 500, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
 gaierror: [Errno -2] Name or service not known
 Logged from file /home/hiseq/mailtest.py, line 11
 [2011-04-12 08:45] INFO: mailtest.log: Hello world
</pre>


And when I define a server_addr, it's not clear to me how to define it since later on the code:

```
        host, port = self.server_addr
```

In which format should the server_addr argument be supplied during "__init__" on MailHandler ?
