### PR TITLE
Broken documentation/feature

### DIFF
--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -130,7 +130,7 @@ class Handler(ContextObject):
     setting bubbling to `True`.  This setup for example would not have
     any effect::
 
-        handler = NullHandler(bubble=False)
+        handler = NullHandler(bubble=True)
         handler.push_application()
 
     Whereas this setup disables all logging for the application::


### PR DESCRIPTION
The specific example in the handler.BaseHandler docs does not work, see https://gist.github.com/2036228 for a test case. One issue is that the docs have confused True and False in the example. Fixing that, it stil does not work, however.

The "shortcut" in logbook/base.py:899 seems to be the issue:

``` python

            # if this is a blackhole handler, don't even try to
            # do further processing, stop right away.  Technically
            # speaking this is not 100% correct because if the handler
            # is bubbling we shouldn't apply this logic, but then we
            # won't enter this branch anyways.  The result is that a
            # bubbling blackhole handler will never have this shortcut
            # applied and do the heavy init at one point.  This is fine
            # however because a bubbling blackhole handler is not very
            # useful in general.
            if handler.blackhole:
                break
```

This is the only application of the blackhole-feature that I could find and it breaks it (disabling the check causes everything to work as expected).

Please have a look at the very simple test case I've provided.
