### PR TITLE
Feature - DatabaseHandler with CouchDB backend

### DIFF
--- a/logbook/ticketing.py
+++ b/logbook/ticketing.py
@@ -386,29 +386,6 @@ class MongoDBBackend(BackendBase):
         return [self._FixedOccurrenceClass(self, obj) for obj in occurrences]
 
 
-class CouchDBBackend(BackendBase):
-    """Implements a backend that writes into a CouchDB database.
-    """
-    def setup_backend(self):
-        from couchdb import Server
-
-        uri = self.options.pop('uri', u'')
-        couch = Server(uri)
-        db_name = self.options.pop('db')
-        self.database = couch[db_name]
-
-    def record_ticket(self, record, data, hash, app_id):
-        """Records a log record as ticket.
-        """
-        db = self.database
-
-        ticket = record.to_dict()
-        ticket["time"] = ticket["time"].isoformat() + "Z"
-        ticket_id, _ = db.save(ticket)
-                
-        db.save(ticket)
-
-
 class TicketingBaseHandler(Handler, HashingHandlerMixin):
     """Baseclass for ticketing handlers.  This can be used to interface
     ticketing systems that do not necessarily provide an interface that


### PR DESCRIPTION
Hi, here at @scilifelab we want to log some things in a data analysis pipeline in to a CouchDB database.

By using the database writing functionality from `ticketing.py` I have implemented a backend which writes the entire log record to a specified couchdb database as a document. To avoid confusion, since these would not be "tickets", I aliased `TicketHandler` as `DatabaseHandler` in `more.py`. And I put the `CouchDBBackend` in `more.py` as well.

All in all, this patch enables this functionality:

``` python
from logbook import Logger
from logbook.more import DatabaseHandler
from logbook.more import CouchDBBackend

log = Logger("Testbook")
handler = DatabaseHandler('http://localhost:5984', \
                            backend=CouchDBBackend, \
                             db='logging_test')

with handler:
    log.info("Hello world!")
```

We where thinking this might be useful for more people!

On a sidenote, we noticed that development seem to have decreased somewhat, and were thinking about e.g. having a look at the current pull requests to your repo and see if we should merge those, and perhaps pick up development some.
