### PR TITLE
Use global zmq context

### DIFF
--- a/logbook/queues.py
+++ b/logbook/queues.py
@@ -74,7 +74,7 @@ class ZeroMQHandler(Handler):
             raise RuntimeError('The pyzmq library is required for '
                                'the ZeroMQHandler.')
         #: the zero mq context
-        self.context = context or zmq.Context()
+        self.context = context or zmq.Context.instance()
         #: the zero mq socket.
         self.socket = self.context.socket(zmq.PUB)
         if uri is not None:


### PR DESCRIPTION
This change lets the ZeroMQHandler to be initialized several times from the same process (works for multithreaded).
http://zeromq.github.com/pyzmq/changelog.html#id12

Won't work for multi-processed applications though. For that you just have to make sure you're initializing the zmq.Context after the forks have taken place.
