### PR TITLE
Fix writing of unicode strings to streams in Python 2

### DIFF
--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -547,7 +547,8 @@ class StreamHandler(Handler, StringFormatterHandlerMixin):
         """Formats the record and encodes it to the stream encoding."""
         stream = self.stream
         rv = self.format(record) + '\n'
-        if not is_unicode(rv) and (PY2 or not _is_text_stream(stream)):
+        if (PY2 and is_unicode(rv)) or \
+                not (PY2 or is_unicode(rv) or _is_text_stream(stream)):
             enc = self.encoding
             if enc is None:
                 enc = getattr(stream, 'encoding', None) or 'utf-8'


### PR DESCRIPTION
When writing a unicode string to a file in Python 2, the string needs to be encoded before writing. This was handled properly in Logbook 0.4.1, but a bug was introduced in 0.4.2 which prevented this encoding from working properly.

The resulting problem can be reproduced easily by running this simple script with Logbook 0.4.2 on Python 2:

```
import logbook

log_handler = logbook.FileHandler('foo.log')
log_handler.push_application()
log = logbook.Logger('Foo')
str = u'\u0431'
log.info(str)
```

It results in this error within format_and_encode:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0431' in position 30: ordinal not in range(128)
```

This commit restores the correct Logbook 0.4.1 behavior for Python 2.
