### PR TITLE
Properly convert record.extra into an ExtraDict

### DIFF
--- a/logbook/base.py
+++ b/logbook/base.py
@@ -474,6 +474,7 @@ class LogRecord(object):
         self._channel = None
         if isinstance(self.time, string_types):
             self.time = parse_iso8601(self.time)
+        self.extra = ExtraDict(self.extra)
         return self
 
     @cached_property


### PR DESCRIPTION
Properly convert record.extra into an ExtraDict while updating record from a dict.
Useful for MessageQueueSubscriber and ZeroMQSubscriber.
Closes mitsuhiko/logbook#68
