### PR TITLE
fix greenlet mocking when gevent is not installed and push_greenlet/pop_...

### DIFF
--- a/logbook/concurrency.py
+++ b/logbook/concurrency.py
@@ -123,8 +123,7 @@ else:
     def thread_get_name():
         return currentThread().getName()
 
-    def greenlet_get_ident():
-        return 1
+    greenlet_get_ident = thread_get_ident
 
     greenlet_local = thread_local
 


### PR DESCRIPTION
Fix when gevent is not installed and we're mocking greenlets, but someone calls greenletbound() or using push_greenlet/pop_greenlet and also using multiple threads.
