### PR TITLE
Unify helper imports in base.py

### DIFF
--- a/logbook/base.py
+++ b/logbook/base.py
@@ -14,11 +14,10 @@ import traceback
 from itertools import chain
 from weakref import ref as weakref
 from datetime import datetime
-from logbook import helpers
 from logbook.concurrency import thread_get_name, thread_get_ident, greenlet_get_ident
 
 from logbook.helpers import to_safe_json, parse_iso8601, cached_property, \
-     PY2, u, string_types, iteritems, integer_types
+     PY2, u, string_types, iteritems, integer_types, xrange
 try:
     from logbook._speedups import group_reflected_property, \
          ContextStackManager, StackedObject
@@ -561,7 +560,7 @@ class LogRecord(object):
         while frm is not None and frm.f_globals is globs:
             frm = frm.f_back
 
-        for _ in helpers.xrange(self.frame_correction):
+        for _ in xrange(self.frame_correction):
             frm = frm.f_back
 
         return frm


### PR DESCRIPTION
why is there a lonely `from logbook import helpers` there