### PR TITLE
Set up PyPI deployment for Windows wheels.

### DIFF
--- a/.appveyor/after_test.bat
+++ b/.appveyor/after_test.bat
@@ -1,0 +1,6 @@
+IF DEFINED CYBUILD (
+	%WITH_COMPILER% python setup.py bdist_wheel
+	IF "%APPVEYOR_REPO_TAG%"=="true" (
+		twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% dist\*.whl
+	)
+)

--- a/.appveyor/prepare.bat
+++ b/.appveyor/prepare.bat
@@ -9,4 +9,5 @@ python setup.py develop
 IF DEFINED CYBUILD (
 	cython logbook\_speedups.pyx
 	%WITH_COMPILER% python setup.py build
+	pip install twine
 )

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Welcome to Logbook
 
-|                       |                                                                                    |
-|-----------------------|------------------------------------------------------------------------------------|
-| Build Status          | ![Build Status] (https://secure.travis-ci.org/getlogbook/logbook.png?branch=master) |
-| Supported Versions    | ![Supported Versions] (https://img.shields.io/pypi/pyversions/logbook.svg)    |
-| Downloads             | ![Downloads] (https://img.shields.io/pypi/dm/logbook.svg)                       |
-| Latest Version        | ![Latest Version] (https://img.shields.io/pypi/v/logbook.svg)                  |
+|                    |                             |
+|--------------------|-----------------------------|
+| Travis             | [![Build Status][ti]][tl]   |
+| AppVeyor           | [![Build Status][ai]][al]   |
+| Supported Versions | ![Supported Versions][vi]   |
+| Downloads          | ![Downloads][di]            |
+| Latest Version     | [![Latest Version][pi]][pl] |
 
 
 Logbook is a nice logging replacement.
@@ -13,3 +14,12 @@ Logbook is a nice logging replacement.
 It should be easy to setup, use and configure and support web applications :)
 
 For more information: http://logbook.readthedocs.org
+
+[ti]: https://secure.travis-ci.org/getlogbook/logbook.svg?branch=master
+[tl]: https://travis-ci.org/getlogbook/logbook
+[ai]: https://ci.appveyor.com/api/projects/status/est77w7podkj83aw/branch/master?svg=true
+[vi]: https://img.shields.io/pypi/pyversions/logbook.svg
+[di]: https://img.shields.io/pypi/dm/logbook.svg
+[al]: https://ci.appveyor.com/project/vmalloc/logbook
+[pi]: https://img.shields.io/pypi/v/logbook.svg
+[pl]: https://pypi.python.org/pypi/Logbook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\.appveyor\\run_with_compiler.cmd"
+    PYPI_USERNAME:
+      secure: wZdQlOvf+UeH5BUG6l7ANw==
+    PYPI_PASSWORD:
+      secure: wZdQlOvf+UeH5BUG6l7ANw==
 
   matrix:
     # Python 2.6.6 is the latest Python 2.6 with a Windows installer
@@ -146,7 +150,7 @@ test_script:
   - py.test -r s tests
 
 after_test:
-  - "IF DEFINED CYBUILD (%WITH_COMPILER% python setup.py bdist_wheel)"
+  - ".appveyor\\after_test.bat"
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.


### PR DESCRIPTION
This pull request addresses #160. Wheels are uploaded when a tag is pushed.

I have also added AppVeyor badge to the README. While doing so, I made the badges link to Travis/AppVeyor pages. Likewise, PyPI badge links to PyPI.

After merging, the following needs done:
- Set `PYPI_*` secure environment variables in `appveyor.yml`.
- Change the AppVeyor image link to the link [found here](https://ci.appveyor.com/project/vmalloc/logbook/settings/badges) (AppVeyor uses private links, so I don't know it.)