### PR TITLE
Improve documentation for library developers, add enable/disable methods.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,7 +160,7 @@ html_static_path = ['_static']
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True
 
-html_add_permalinks = False
+html_add_permalinks = ''
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -52,6 +52,104 @@ Best Practices
     stack in a function and not reverting it at the end of the function is
     bad.
 
+Example Setup
+-------------
+
+Consider how your logger should be configured by default. Users familiar with
+:mod:`logging` from the standard library probably expect your logger to be
+disabled by default::
+
+    import yourmodule
+    import logbook
+
+    yourmodule.logger.enable()
+
+    def main():
+        ...
+        yourmodule.something()
+        ...
+
+    if __name__ == '__main__':
+        with logbook.StderrHandler():
+            main()
+
+or set to a high level (e.g. `WARNING`) by default, allowing them to opt in to
+more detail if desired::
+
+    import yourmodule
+    import logbook
+
+    yourmodule.logger.level = logbook.WARNING
+
+    def main():
+        ...
+        yourmodule.something()
+        ...
+
+    if __name__ == '__main__':
+        with logbook.StderrHandler():
+            main()
+
+Either way, make sure to document how your users can enable your logger,
+including basic use of logbook handlers. Some users may want to continue using
+:mod:`logging`, so you may want to link to
+:class:`~logbook.compat.LoggingHandler`.
+
+Multiple Logger Example Setup
+-----------------------------
+
+You may want to use multiple loggers in your library. It may be worthwhile to
+add a logger group to allow the level or disabled attributes of all your
+loggers to be set at once.
+
+For example, your library might look something like this:
+
+.. code-block:: python
+   :caption: yourmodule/__init__.py
+
+    from .log import logger_group
+
+.. code-block:: python
+    :caption: yourmodule/log.py
+
+    import logbook
+
+    logger_group = logbook.LoggerGroup()
+    logger_group.level = logbook.WARNING
+
+.. code-block:: python
+    :caption: yourmodule/engine.py
+
+    from logbook import Logger
+    from .log import logger_group
+
+    logger = Logger('yourmodule.engine')
+    logger_group.add_logger(logger)
+
+.. code-block:: python
+    :caption: yourmodule/parser.py
+
+    from logbook import Logger
+    from .log import logger_group
+
+    logger = Logger('yourmodule.parser')
+    logger_group.add_logger(logger)
+
+The library user can then choose what level of logging they would like from
+your library::
+
+    import logbook
+    import yourmodule
+
+    yourmodule.logger_group.level = logbook.INFO
+
+They might only want to see debug messages from one of the loggers::
+
+    import logbook
+    import yourmodule
+
+    yourmodule.engine.logger.level = logbook.DEBUG
+
 Debug Loggers
 -------------
 

--- a/logbook/helpers.py
+++ b/logbook/helpers.py
@@ -167,9 +167,10 @@ if os.name == 'nt':
             os.rename(src, dst)
         except OSError:
             e = sys.exc_info()[1]
-            if e.errno != errno.EEXIST:
+            print(e.errno, errno.EACCES, errno.EPERM)
+            if e.errno not in (errno.EEXIST, errno.EACCES):
                 raise
-            old = "%s-%08x" % (dst, random.randint(0, sys.maxint))
+            old = "%s-%08x" % (dst, random.randint(0, 2 ** 31 - 1))
             os.rename(dst, old)
             os.rename(src, dst)
             try:

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -13,3 +13,79 @@ def test_groups(logger):
     assert (not handler.has_warning('A warning'))
     assert handler.has_error('An error')
     assert handler.records[0].extra['foo'] == 'bar'
+
+
+def test_group_disabled():
+    group = logbook.LoggerGroup()
+    logger1 = logbook.Logger('testlogger1')
+    logger2 = logbook.Logger('testlogger2')
+
+    group.add_logger(logger1)
+    group.add_logger(logger2)
+
+    # Test group disable
+
+    group.disable()
+
+    with logbook.TestHandler() as handler:
+        logger1.warn('Warning 1')
+        logger2.warn('Warning 2')
+
+    assert not handler.has_warnings
+
+    # Test group enable
+
+    group.enable()
+
+    with logbook.TestHandler() as handler:
+        logger1.warn('Warning 1')
+        logger2.warn('Warning 2')
+
+    assert handler.has_warning('Warning 1')
+    assert handler.has_warning('Warning 2')
+
+    # Test group disabled, but logger explicitly enabled
+
+    group.disable()
+
+    logger1.enable()
+
+    with logbook.TestHandler() as handler:
+        logger1.warn('Warning 1')
+        logger2.warn('Warning 2')
+
+    assert handler.has_warning('Warning 1')
+    assert not handler.has_warning('Warning 2')
+
+    # Logger 1 will be enabled by using force=True
+
+    group.disable(force=True)
+
+    with logbook.TestHandler() as handler:
+        logger1.warn('Warning 1')
+        logger2.warn('Warning 2')
+
+    assert not handler.has_warning('Warning 1')
+    assert not handler.has_warning('Warning 2')
+
+    # Enabling without force means logger 1 will still be disabled.
+
+    group.enable()
+
+    with logbook.TestHandler() as handler:
+        logger1.warn('Warning 1')
+        logger2.warn('Warning 2')
+
+    assert not handler.has_warning('Warning 1')
+    assert handler.has_warning('Warning 2')
+
+    # Force logger 1 enabled.
+
+    group.enable(force=True)
+
+    with logbook.TestHandler() as handler:
+        logger1.warn('Warning 1')
+        logger2.warn('Warning 2')
+
+    assert handler.has_warning('Warning 1')
+    assert handler.has_warning('Warning 2')

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,4 +1,5 @@
 import logbook
+import pytest
 
 
 def test_level_properties(logger):
@@ -26,3 +27,18 @@ def test_reflected_properties(logger):
     assert logger.level_name == 'CRITICAL'
     group.remove_logger(logger)
     assert logger.group is None
+
+
+def test_disabled_property():
+    class MyLogger(logbook.Logger):
+        @property
+        def disabled(self):
+            return True
+
+    logger = MyLogger()
+
+    with pytest.raises(AttributeError):
+        logger.enable()
+
+    with pytest.raises(AttributeError):
+        logger.disable()


### PR DESCRIPTION
I added `enable` and `disable` methods to both `LoggerMixin` and `LoggerGroup`. I think these make more sense from a user's perspective than setting a negative True or False.

If anything, perhaps the `force` parameter to the `LoggerGroup` `enable`/`disable` methods shouldn't be included.

The main reason for this pull request is the documentation additions for library developers.