### PR TITLE
Enable set_datetime_format to take a user-supplied factory function

### DIFF
--- a/logbook/base.py
+++ b/logbook/base.py
@@ -49,6 +49,9 @@ def set_datetime_format(datetime_format):
          "local"
              :py:attr:`LogRecord.time` will be a datetime in local time zone
              (but not time zone aware)
+         A `callable` returning datetime instances
+            :py:attr:`LogRecord.time` will be a datetime created by
+            :py:param:`datetime_format` (possibly time zone aware)
 
     This function defaults to creating datetime objects in UTC time,
     using `datetime.utcnow()
@@ -69,12 +72,30 @@ def set_datetime_format(datetime_format):
        from datetime import datetime
        logbook.set_datetime_format("local")
 
+    Other uses rely on your supplied :py:param:`datetime_format`.
+    Using `pytz <https://pypi.python.org/pypi/pytz>`_ for example::
+
+        from datetime import datetime
+        import logbook
+        import pytz
+
+        def utc_tz():
+            return datetime.now(tz=pytz.utc)
+
+        logbook.set_datetime_format(utc_tz)
     """
     global _datetime_factory
     if datetime_format == "utc":
         _datetime_factory = datetime.utcnow
     elif datetime_format == "local":
         _datetime_factory = datetime.now
+    elif callable(datetime_format):
+        inst = datetime_format()
+        if not isinstance(inst, datetime):
+            raise ValueError("Invalid callable value, valid callable "
+                             "should return datetime.datetime instances, "
+                             "not %r" % (type(inst),))
+        _datetime_factory = datetime_format
     else:
         raise ValueError("Invalid value %r.  Valid values are 'utc' and "
                          "'local'." % (datetime_format,))

--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -34,7 +34,7 @@ from logbook.helpers import (
 from logbook.concurrency import new_fine_grained_lock
 
 DEFAULT_FORMAT_STRING = u(
-    '[{record.time:%Y-%m-%d %H:%M:%S.%f}] '
+    '[{record.time:%Y-%m-%d %H:%M:%S.%f%z}] '
     '{record.level_name}: {record.channel}: {record.message}')
 
 SYSLOG_FORMAT_STRING = u('{record.channel}: {record.message}')

--- a/tests/test_logging_times.py
+++ b/tests/test_logging_times.py
@@ -76,3 +76,20 @@ def test_tz_aware(activation_strategy, logger):
             logbook.set_datetime_format('utc')
 
     assert record.time.tzinfo is not None
+
+
+def test_invalid_time_factory():
+    """
+    tests logbook.set_datetime_format() with an invalid time factory callable
+    """
+    def invalid_factory():
+        return False
+
+    with pytest.raises(ValueError) as e:
+        try:
+            logbook.set_datetime_format(invalid_factory)
+        finally:
+            # put back the default time factory
+            logbook.set_datetime_format('utc')
+
+    assert 'Invalid callable value' in str(e.value)


### PR DESCRIPTION
Switching between utc and local timestamps is all well and good, but for proper correlation of logs between sources, the inclusion of a timezone makes things **a lot** easier to follow. This PR enables that in a (I think) backwards compatible way:

- Add `%z` to the default format string (`%z` is safe in that it will include an empty string for `LogRecord.time` without a time zone);
- Enable user-supplied datetime factory for `logbook.set_datetime_format` as long as it provides `datetime.datetime` instances.

I :heart: logbook with all my :heart:, but this one's been bugging me for a while. Using a simple wrapper, I get 'nice' (well, for me) messages including the time zone like `+0000` for UTC:

~~~~ python
def utc_tz():
    return datetime.now(tz=timezone.utc)

logbook.set_datetime_format(utc_tz)

logbook.info('I am now logging with time zone aware timestamps! :o')
~~~~

~~~~
[2016-05-09 14:54:32.925248+0000] INFO: Generic: I am now logging with time zone aware timestamps! :o
~~~~