### PR TITLE
Don't hardcode errno constant

### DIFF
--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -668,7 +668,7 @@ class MonitoringFileHandler(FileHandler):
                 st = os.stat(self._filename)
             except OSError:
                 e = sys.exc_info()[1]
-                if e.errno != 2:
+                if e.errno != errno.ENOENT:
                     raise
                 self._last_stat = None, None
             else:


### PR DESCRIPTION
The value of `ENOENT` is architecture-dependent, so don't assume it's always 2.

This bug was found using [pydiatra](https://github.com/jwilk/pydiatra).
