### PR TITLE
RiemannHandler implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 - sudo apt-get update
 - sudo apt-get install -y libzmq3-dev
 - pip install -U pip
+- pip install riemann-client
 - pip install cython
 - cython logbook/_speedups.pyx
 env:

--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -33,7 +33,6 @@ from logbook.helpers import (
     integer_types, reraise, u, with_metaclass)
 from logbook.concurrency import new_fine_grained_lock
 
-
 DEFAULT_FORMAT_STRING = u(
     '[{record.time:%Y-%m-%d %H:%M:%S.%f%z}] '
     '{record.level_name}: {record.channel}: {record.message}')

--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -21,9 +21,6 @@ except ImportError:
     from sha import new as sha1
 import traceback
 import collections
-
-import platform
-
 from datetime import datetime, timedelta
 from collections import deque
 from textwrap import dedent
@@ -35,7 +32,6 @@ from logbook.helpers import (
     rename, b, _is_text_stream, is_unicode, PY2, zip, xrange, string_types,
     integer_types, reraise, u, with_metaclass)
 from logbook.concurrency import new_fine_grained_lock
-from riemann_client import client as riemann, transport
 
 
 DEFAULT_FORMAT_STRING = u(
@@ -991,55 +987,6 @@ class TestHandler(Handler, StringFormatterHandlerMixin):
                 continue
             return True
         return False
-
-
-class RiemannHandler(Handler):
-
-    """
-    A handler that sends logs as events to Riemann.
-    """
-
-    def __init__(self, host, port, message_type="tcp", ttl=60, bubble=False):
-        self.host = host
-        self.port = port
-        self.ttl = ttl
-        if message_type == "tcp":
-            self.transport = transport.TCPTransport
-        elif message_type == "udp":
-            self.transport = transport.UDPTransport
-        else:
-            msg = ("Currently supported message types for RiemannHandler are: {0}. \
-                    {1} is not supported."
-                   .format(",".join(["tcp", "udp"], message_type)))
-            raise RuntimeError(msg)
-
-    def record_to_event(self, record):
-        tags = ["log", record.level_name]
-        msg = record.exc_info if record.exc_info else record.msg
-        channel_name = str(record.channel) if record.channel else "unknown"
-        if any([record.level_name == keywords
-                for keywords in ["ERROR", "EXCEPTION"]]):
-            state = "error"
-        else:
-            state = "ok"
-        return {"metric_f": 1.0,
-                "tags": tags,
-                "description": msg,
-                "time": record.time.isoformat(),
-                "ttl": self.ttl,
-                "host": platform.node(),
-                "service": "{0}.{1}".format(channel_name, os.getpid()),
-                "state": state
-                }
-
-    def emit(self, record):
-        self.emit_batch([record])
-
-    def emit_batch(self, records):
-        with riemann.QueuedClient(self.transport(self.host, self.port)) as cl:
-            for record in records:
-                cl.event(**self.record_to_event(record))
-            cl.flush()
 
 
 class MailHandler(Handler, StringFormatterHandlerMixin,

--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -32,6 +32,8 @@ from logbook.helpers import (
     rename, b, _is_text_stream, is_unicode, PY2, zip, xrange, string_types,
     integer_types, reraise, u, with_metaclass)
 from logbook.concurrency import new_fine_grained_lock
+from riemann_client import client, transport
+
 
 DEFAULT_FORMAT_STRING = u(
     '[{record.time:%Y-%m-%d %H:%M:%S.%f%z}] '
@@ -986,6 +988,29 @@ class TestHandler(Handler, StringFormatterHandlerMixin):
                 continue
             return True
         return False
+
+
+class RiemannHandler(Handler):
+
+    """
+    A handler that sends logs as events to Riemann.
+    """
+
+    def __init__(self, host, port, message_type="tcp", tls_key=None, bubble=False):
+        self.host = host
+        self.port = port
+        if message_type == "tcp":
+            self.transport = transport.TCPTransport
+        elif message_type == "udp":
+            self.transport = transport.UDPTransport
+        else:
+            msg = ("Currently supported message types for RiemannHandler are: {0}. \
+                    {1} is not supported."
+                   .format(",".join(["tcp", "udp"], message_type)))
+            raise RuntimeError(msg)
+
+    def emit(self, record):
+        pass
 
 
 class MailHandler(Handler, StringFormatterHandlerMixin,

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -479,7 +479,7 @@ class RiemannHandler(Handler):
     def record_to_event(self, record):
         from time import time
         tags = ["log", record.level_name]
-        msg = record.exc_info if record.exc_info else record.msg
+        msg = str(record.exc_info[1]) if record.exc_info else record.msg
         channel_name = str(record.channel) if record.channel else "unknown"
         if any([record.level_name == keywords
                 for keywords in ["ERROR", "EXCEPTION"]]):

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -458,7 +458,15 @@ class RiemannHandler(Handler):
     A handler that sends logs as events to Riemann.
     """
 
-    def __init__(self, host, port, message_type="tcp", ttl=60, flush_threshold=10, bubble=False):
+    def __init__(self,
+                 host,
+                 port,
+                 message_type="tcp",
+                 ttl=60,
+                 flush_threshold=10,
+                 bubble=False,
+                 filter=None,
+                 level=NOTSET):
         """
         :param host: riemann host
         :param port: riemann port
@@ -466,10 +474,10 @@ class RiemannHandler(Handler):
         :param ttl: defines time to live in riemann
         :param flush_threshold: count of events after which we send to riemann
         """
+        Handler.__init__(self, level, filter, bubble)
         self.host = host
         self.port = port
         self.ttl = ttl
-        self.bubble = bubble
         self.queue = []
         self.flush_threshold = flush_threshold
         if message_type == "tcp":

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -459,9 +459,17 @@ class RiemannHandler(Handler):
     """
 
     def __init__(self, host, port, message_type="tcp", ttl=60, flush_threshold=10, bubble=False):
+        """
+        :param host: riemann host
+        :param port: riemann port
+        :param message_type: selects transport. Currently available 'tcp' and 'udp'
+        :param ttl: defines time to live in riemann
+        :param flush_threshold: count of events after which we send to riemann
+        """
         self.host = host
         self.port = port
         self.ttl = ttl
+        self.bubble = bubble
         self.queue = []
         self.flush_threshold = flush_threshold
         if message_type == "tcp":

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -24,7 +24,7 @@ from logbook.helpers import PY2, string_types, iteritems, u
 from logbook.ticketing import TicketingHandler as DatabaseHandler
 from logbook.ticketing import BackendBase
 from riemann_client.client import QueuedClient
-from riemann_client.transport import TCPTransport, UDPTransport
+from riemann_client.transport import TCPTransport, UDPTransport, BlankTransport
 
 if PY2:
     from urllib import urlencode
@@ -466,10 +466,12 @@ class RiemannHandler(Handler):
             self.transport = TCPTransport
         elif message_type == "udp":
             self.transport = UDPTransport
+        elif message_type == "test":
+            self.transport = BlankTransport
         else:
             msg = ("Currently supported message types for RiemannHandler are: {0}. \
                     {1} is not supported."
-                   .format(",".join(["tcp", "udp"], message_type)))
+                   .format(",".join(["tcp", "udp", "test"], message_type)))
             raise RuntimeError(msg)
 
     def record_to_event(self, record):

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -481,7 +481,7 @@ class RiemannHandler(Handler):
         else:
             msg = ("Currently supported message types for RiemannHandler are: {0}. \
                     {1} is not supported."
-                   .format(",".join(["tcp", "udp", "test"], message_type)))
+                   .format(",".join(["tcp", "udp", "test"]), message_type))
             raise RuntimeError(msg)
 
     def record_to_event(self, record):

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -11,6 +11,9 @@
 import re
 import os
 import platform
+
+import riemann_client
+
 from collections import defaultdict
 from functools import partial
 
@@ -20,10 +23,8 @@ from logbook.handlers import (
     Handler, StringFormatter, StringFormatterHandlerMixin, StderrHandler)
 from logbook._termcolors import colorize
 from logbook.helpers import PY2, string_types, iteritems, u
-
 from logbook.ticketing import TicketingHandler as DatabaseHandler
 from logbook.ticketing import BackendBase
-from riemann_client import client as riemann, transport
 
 if PY2:
     from urllib import urlencode
@@ -462,9 +463,9 @@ class RiemannHandler(Handler):
         self.port = port
         self.ttl = ttl
         if message_type == "tcp":
-            self.transport = transport.TCPTransport
+            self.transport = riemann_client.transport.TCPTransport
         elif message_type == "udp":
-            self.transport = transport.UDPTransport
+            self.transport = riemann_client.transport.UDPTransport
         else:
             msg = ("Currently supported message types for RiemannHandler are: {0}. \
                     {1} is not supported."
@@ -494,7 +495,7 @@ class RiemannHandler(Handler):
         self.emit_batch([record])
 
     def emit_batch(self, records):
-        with riemann.QueuedClient(self.transport(self.host, self.port)) as cl:
+        with riemann_client.client.QueuedClient(self.transport(self.host, self.port)) as cl:
             for record in records:
                 cl.event(**self.record_to_event(record))
             cl.flush()

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -473,6 +473,7 @@ class RiemannHandler(Handler):
             raise RuntimeError(msg)
 
     def record_to_event(self, record):
+        from time import time
         tags = ["log", record.level_name]
         msg = record.exc_info if record.exc_info else record.msg
         channel_name = str(record.channel) if record.channel else "unknown"
@@ -484,7 +485,7 @@ class RiemannHandler(Handler):
         return {"metric_f": 1.0,
                 "tags": tags,
                 "description": msg,
-                "time": record.time.isoformat(),
+                "time": int(time()),
                 "ttl": self.ttl,
                 "host": platform.node(),
                 "service": "{0}.{1}".format(channel_name, os.getpid()),

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ extras_require['sqlalchemy'] = set(['sqlalchemy'])
 extras_require['redis'] = set(['redis'])
 extras_require['zmq'] = set(['pyzmq'])
 extras_require['jinja'] = set(['Jinja2'])
-extras_require['riemann'] = set(['python-riemann-client'])
+extras_require['riemann'] = set(['riemann-client'])
 
 extras_require['all'] = set(chain.from_iterable(extras_require.values()))
 

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ extras_require['sqlalchemy'] = set(['sqlalchemy'])
 extras_require['redis'] = set(['redis'])
 extras_require['zmq'] = set(['pyzmq'])
 extras_require['jinja'] = set(['Jinja2'])
+extras_require['riemann'] = set(['python-riemann-client'])
 
 extras_require['all'] = set(chain.from_iterable(extras_require.values()))
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -145,3 +145,22 @@ def test_dedup_handler(logger):
     assert 2 == len(test_handler.records)
     assert 'message repeated 2 times: foo' in test_handler.records[0].message
     assert 'message repeated 1 times: bar' in test_handler.records[1].message
+
+
+def test_riemann_handler(activation_strategy, logger):
+    from logbook.more import RiemannHandler
+    riemann_handler = RiemannHandler("127.0.0.1", 5555, message_type="test")
+    handler = logbook.FingersCrossedHandler(riemann_handler, reset=True)
+    with activation_strategy(handler):
+        logger.error("Something bad has happened")
+        try:
+            raise RuntimeError("For example, a RuntimeError")
+        except Exception as ex:
+            logger.exception(ex)
+
+    q = riemann_handler.queue
+    assert len(q) == 2
+    error_event = q[0]
+    assert error_event["state"] == "error"
+    exc_event = q[1]
+    assert exc_event["description"] == "For example, a RuntimeError"

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -177,3 +177,22 @@ class TestRiemannHandler(object):
         from logbook.more import RiemannHandler
         with pytest.raises(RuntimeError):
             RiemannHandler("127.0.0.1", 5555, message_type="fancy_type")
+
+    @require_module("riemann_client")
+    def test_flush(self, logger):
+        from logbook.more import RiemannHandler
+        riemann_handler = RiemannHandler("127.0.0.1",
+                                         5555,
+                                         message_type="test",
+                                         flush_threshold=2,
+                                         level=logbook.INFO)
+        null_handler = logbook.NullHandler()
+        with null_handler.applicationbound():
+            with riemann_handler:
+                logger.info("Msg #1")
+                logger.info("Msg #2")
+                logger.info("Msg #3")
+
+        q = riemann_handler.queue
+        assert len(q) == 1
+        assert q[0]["description"] == "Msg #3"


### PR DESCRIPTION
New handler type which allows to push logs to Riemann via TCP or UDP.

Currently missing: TLS support, and `riemann-client` (https://github.com/borntyping/python-riemann-client) uses experimental protobuf support for Python 3. However, I haven't got any issues with it.