### PR TITLE
Add Python 3.6 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 - pypy
 - pypy3
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,14 @@ environment:
     - PYTHON: "C:\\Python35-x64"
       CYBUILD: "TRUE"
 
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36"
+      CYBUILD: "TRUE"
+
+    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python36-x64"
+      CYBUILD: "TRUE"
+
 init:
   - echo %PYTHON%
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%


### PR DESCRIPTION
Working on Travis, but still waiting on AppVeyor Python 3.6 support.

- [ ] https://github.com/appveyor/ci/issues/1237