### PR TITLE
Issue #254 Added more control for rollover naming

### DIFF
--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -29,7 +29,8 @@ from textwrap import dedent
 
 from logbook.base import (
     CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, NOTSET, level_name_property,
-    _missing, lookup_level, Flags, ContextObject, ContextStackManager)
+    _missing, lookup_level, Flags, ContextObject, ContextStackManager,
+    _datetime_factory)
 from logbook.helpers import (
     rename, b, _is_text_stream, is_unicode, PY2, zip, xrange, string_types,
     integer_types, reraise, u, with_metaclass)
@@ -867,29 +868,61 @@ class TimedRotatingFileHandler(FileHandler):
 
     By default it will keep all these files around, if you want to limit
     them, you can specify a `backup_count`.
+
+    You may supply an optional `rollover_format`. This allows you to specify
+    the format for the filenames of rolled-over files.
+    the format as
+
+    So for example if you configure your handler like this::
+
+        handler = TimedRotatingFileHandler(
+            '/var/log/foo.log',
+            date_format='%Y-%m-%d',
+            rollover_format='{basename}{ext}.{timestamp}')
+
+    The filenames for the logfiles will look like this::
+
+        /var/log/foo.log.2010-01-10
+        /var/log/foo.log.2010-01-11
+        ...
+
+    Finally, an optional argument `timed_filename_for_current` may be set to
+    false if you wish to have the current log file match the supplied filename
+    until it is rolled over
     """
 
     def __init__(self, filename, mode='a', encoding='utf-8', level=NOTSET,
                  format_string=None, date_format='%Y-%m-%d',
-                 backup_count=0, filter=None, bubble=False):
-        FileHandler.__init__(self, filename, mode, encoding, level,
-                             format_string, True, filter, bubble)
+                 backup_count=0, filter=None, bubble=False,
+                 timed_filename_for_current=True,
+                 rollover_format='{basename}-{timestamp}{ext}'):
         self.date_format = date_format
         self.backup_count = backup_count
-        self._fn_parts = os.path.splitext(os.path.abspath(filename))
-        self._filename = None
 
-    def _get_timed_filename(self, datetime):
-        return (datetime.strftime('-' + self.date_format)
-                .join(self._fn_parts))
+        self.rollover_format = rollover_format
 
-    def should_rollover(self, record):
-        fn = self._get_timed_filename(record.time)
-        rv = self._filename is not None and self._filename != fn
-        # remember the current filename.  In case rv is True, the rollover
-        # performing function will already have the new filename
-        self._filename = fn
-        return rv
+        self.original_filename = filename
+        self.basename, self.ext = os.path.splitext(os.path.abspath(filename))
+        self.timed_filename_for_current = timed_filename_for_current
+
+        self._timestamp = self.get_timestamp(_datetime_factory())
+        timed_filename = self.compute_name(self._timestamp)
+
+        if self.timed_filename_for_current:
+            filename = timed_filename
+
+        FileHandler.__init__(self, filename, mode, encoding, level,
+                             format_string, True, filter, bubble)
+
+    def get_timestamp(self, datetime):
+        return datetime.strftime(self.date_format)
+
+    def compute_name(self, timestamp):
+        timed_filename = self.rollover_format.format(
+            basename=self.basename,
+            timestamp=timestamp,
+            ext=self.ext)
+        return timed_filename
 
     def files_to_delete(self):
         """Returns a list with the files that have to be deleted when
@@ -899,8 +932,12 @@ class TimedRotatingFileHandler(FileHandler):
         files = []
         for filename in os.listdir(directory):
             filename = os.path.join(directory, filename)
-            if (filename.startswith(self._fn_parts[0] + '-') and
-                    filename.endswith(self._fn_parts[1])):
+            regex = self.rollover_format.format(
+                basename=re.escape(self.basename),
+                timestamp='.+',
+                ext=re.escape(self.ext),
+            )
+            if re.match(regex, filename):
                 files.append((os.path.getmtime(filename), filename))
         files.sort()
         if self.backup_count > 1:
@@ -908,19 +945,30 @@ class TimedRotatingFileHandler(FileHandler):
         else:
             return files[:]
 
-    def perform_rollover(self):
-        self.stream.close()
+    def perform_rollover(self, new_timestamp):
+        if self.stream is not None:
+            self.stream.close()
+
         if self.backup_count > 0:
             for time, filename in self.files_to_delete():
                 os.remove(filename)
+
+        if self.timed_filename_for_current:
+            self._filename = self.compute_name(new_timestamp)
+        else:
+            filename = self.compute_name(self._timestamp)
+            os.rename(self._filename, filename)
+        self._timestamp = new_timestamp
+
         self._open('w')
 
     def emit(self, record):
         msg = self.format(record)
         self.lock.acquire()
         try:
-            if self.should_rollover(record):
-                self.perform_rollover()
+            new_timestamp = self.get_timestamp(record.time)
+            if new_timestamp != self._timestamp:
+                self.perform_rollover(new_timestamp)
             self.write(self.encode(msg))
             self.flush()
         finally:

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -175,7 +175,7 @@ def test_timed_rotating_file_handler__not_timed_filename_for_current(tmpdir, act
         rollover_format='{basename}{ext}.{timestamp}',
         timed_filename_for_current=False,
     )
-    handler._timestamp = handler.get_timestamp(datetime(2010, 1, 5))
+    handler._timestamp = handler._get_timestamp(datetime(2010, 1, 5))
     handler.format_string = '[{record.time:%H:%M}] {record.message}'
 
     def fake_record(message, year, month, day, hour=0,

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -129,6 +129,84 @@ def test_timed_rotating_file_handler(tmpdir, activation_strategy, backup_count):
             assert f.readline().rstrip() == '[01:00] Third One'
             assert f.readline().rstrip() == '[02:00] Third One'
 
+@pytest.mark.parametrize("backup_count", [1, 3])
+def test_timed_rotating_file_handler__rollover_format(tmpdir, activation_strategy, backup_count):
+    basename = str(tmpdir.join('trot.log'))
+    handler = logbook.TimedRotatingFileHandler(
+        basename, backup_count=backup_count,
+        rollover_format='{basename}{ext}.{timestamp}',
+    )
+    handler.format_string = '[{record.time:%H:%M}] {record.message}'
+
+    def fake_record(message, year, month, day, hour=0,
+                    minute=0, second=0):
+        lr = logbook.LogRecord('Test Logger', logbook.WARNING,
+                               message)
+        lr.time = datetime(year, month, day, hour, minute, second)
+        return lr
+
+    with activation_strategy(handler):
+        for x in xrange(10):
+            handler.handle(fake_record('First One', 2010, 1, 5, x + 1))
+        for x in xrange(20):
+            handler.handle(fake_record('Second One', 2010, 1, 6, x + 1))
+        for x in xrange(10):
+            handler.handle(fake_record('Third One', 2010, 1, 7, x + 1))
+        for x in xrange(20):
+            handler.handle(fake_record('Last One', 2010, 1, 8, x + 1))
+
+    files = sorted(x for x in os.listdir(str(tmpdir)) if x.startswith('trot'))
+
+    assert files == ['trot.log.2010-01-0{0}'.format(i)
+                     for i in xrange(5, 9)][-backup_count:]
+    with open(str(tmpdir.join('trot.log.2010-01-08'))) as f:
+        assert f.readline().rstrip() == '[01:00] Last One'
+        assert f.readline().rstrip() == '[02:00] Last One'
+    if backup_count > 1:
+        with open(str(tmpdir.join('trot.log.2010-01-07'))) as f:
+            assert f.readline().rstrip() == '[01:00] Third One'
+            assert f.readline().rstrip() == '[02:00] Third One'
+
+@pytest.mark.parametrize("backup_count", [1, 3])
+def test_timed_rotating_file_handler__not_timed_filename_for_current(tmpdir, activation_strategy, backup_count):
+    basename = str(tmpdir.join('trot.log'))
+    handler = logbook.TimedRotatingFileHandler(
+        basename, backup_count=backup_count,
+        rollover_format='{basename}{ext}.{timestamp}',
+        timed_filename_for_current=False,
+    )
+    handler._timestamp = handler.get_timestamp(datetime(2010, 1, 5))
+    handler.format_string = '[{record.time:%H:%M}] {record.message}'
+
+    def fake_record(message, year, month, day, hour=0,
+                    minute=0, second=0):
+        lr = logbook.LogRecord('Test Logger', logbook.WARNING,
+                               message)
+        lr.time = datetime(year, month, day, hour, minute, second)
+        return lr
+
+    with activation_strategy(handler):
+        for x in xrange(10):
+            handler.handle(fake_record('First One', 2010, 1, 5, x + 1))
+        for x in xrange(20):
+            handler.handle(fake_record('Second One', 2010, 1, 6, x + 1))
+        for x in xrange(10):
+            handler.handle(fake_record('Third One', 2010, 1, 7, x + 1))
+        for x in xrange(20):
+            handler.handle(fake_record('Last One', 2010, 1, 8, x + 1))
+
+    files = sorted(x for x in os.listdir(str(tmpdir)) if x.startswith('trot'))
+
+    assert files == ['trot.log'] + ['trot.log.2010-01-0{0}'.format(i)
+                     for i in xrange(5, 8)][-backup_count:]
+    with open(str(tmpdir.join('trot.log'))) as f:
+        assert f.readline().rstrip() == '[01:00] Last One'
+        assert f.readline().rstrip() == '[02:00] Last One'
+    if backup_count > 1:
+        with open(str(tmpdir.join('trot.log.2010-01-07'))) as f:
+            assert f.readline().rstrip() == '[01:00] Third One'
+            assert f.readline().rstrip() == '[02:00] Third One'
+
 def _decompress(input_file_name, use_gzip=True):
     if use_gzip:
         with gzip.open(input_file_name, 'rb') as in_f:


### PR DESCRIPTION
In order to match the naming that is used in vanilla logging, I added
two additional options to the TimedRotatingFileHandler:

* rollover_format
  This allows the user to specify the format that the files should be
  named with

* timed_filename_for_current
  When set to false, this will direct the handler to use the supplied
  filename (with no embedded time information) for the current file.
  Only when the date rolls-over will this be renamed to have a
  timestamped filename