### PR TITLE
Add experimental support for contextvars.

### DIFF
--- a/logbook/base.py
+++ b/logbook/base.py
@@ -206,6 +206,15 @@ class ContextObject(StackedObject):
         popped = self.stack_manager.pop_greenlet()
         assert popped is self, 'popped unexpected object'
 
+    def push_context(self):
+        """Pushes the context object to the context stack."""
+        self.stack_manager.push_context(self)
+
+    def pop_context(self):
+        """Pops the context object from the stack."""
+        popped = self.stack_manager.pop_context()
+        assert popped is self, 'popped unexpected object'
+
     def push_thread(self):
         """Pushes the context object to the thread stack."""
         self.stack_manager.push_thread(self)


### PR DESCRIPTION
Python 3.7 has something called contextvars: https://docs.python.org/3/library/contextvars.html They are like thread locals, but are bound to the current asyncio task. Other frameworks, such as trio (https://github.com/python-trio/trio) can (and do) use them as well. I suppose even gevent could use them.

As for as I understand, because they are more fine grained, they are effectively a superset of thread locals as well.

I made some choices here:

- I did not implement the speedups yet, wanted to get some feedback first.
- contextvars do not have any "ident" system (which logbook uses for caching the stack), so I built a custom one.
- The contextvar docs say that a ContextVar should be global because apparently it won't ever be garbage collected, but I think, since there is a limited number of those contextmangers around, it's fine here as class attribute.
- asyncio-like concurrency doesn't need a lock, so I am using a threading-based as the next-higher boundary (say a user has two threads each running an asyncio loop).

I am looking for some feedback, and general guidance as to what is required to get this merged.