### PR TITLE
Replace a deprecated regular expression

### DIFF
--- a/logbook/more.py
+++ b/logbook/more.py
@@ -38,7 +38,7 @@ if PY2:
 else:
     from urllib.parse import parse_qsl, urlencode
 
-_ws_re = re.compile(r'(\s+)(?u)')
+_ws_re = re.compile(r'(\s+)', re.UNICODE)
 TWITTER_FORMAT_STRING = u(
     '[{record.channel}] {record.level_name}: {record.message}')
 TWITTER_ACCESS_TOKEN_URL = 'https://twitter.com/oauth/access_token'


### PR DESCRIPTION
In Python 3.6.6, I encountered the following warning:

```
logbook/more.py:41: DeprecationWarning: Flags not at the start of the expression '(\\s+)(?u)'
  _ws_re = re.compile(r'(\s+)(?u)')
```

Looks like the regular expression `(\s+)(?u)` is now deprecated (and will be removed in a future Python version) according to the official documentation:
https://docs.python.org/3/whatsnew/3.6.html#id5
