### PR TITLE
Update pypi.python.org domain to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ For more information: http://logbook.readthedocs.org
 [di]: https://img.shields.io/pypi/dm/logbook.svg
 [al]: https://ci.appveyor.com/project/vmalloc/logbook
 [pi]: https://img.shields.io/pypi/v/logbook.svg
-[pl]: https://pypi.python.org/pypi/Logbook
+[pl]: https://pypi.org/pypi/Logbook
 [ci]: https://coveralls.io/repos/getlogbook/logbook/badge.svg?branch=master&service=github
 [cl]: https://coveralls.io/github/getlogbook/logbook?branch=master

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,6 @@ Project Information
 * `Mailing list`_
 * IRC: ``#pocoo`` on freenode
 
-.. _Download from PyPI: http://pypi.python.org/pypi/Logbook
+.. _Download from PyPI: https://pypi.org/pypi/Logbook
 .. _Master repository on GitHub: https://github.com/getlogbook/logbook
 .. _Mailing list: http://groups.google.com/group/pocoo-libs

--- a/logbook/base.py
+++ b/logbook/base.py
@@ -79,7 +79,7 @@ def set_datetime_format(datetime_format):
        logbook.set_datetime_format("local")
 
     Other uses rely on your supplied :py:obj:`datetime_format`.
-    Using `pytz <https://pypi.python.org/pypi/pytz>`_ for example::
+    Using `pytz <https://pypi.org/pypi/pytz>`_ for example::
 
         from datetime import datetime
         import logbook

--- a/logbook/more.py
+++ b/logbook/more.py
@@ -327,7 +327,7 @@ class ColorizingStreamHandlerMixin(object):
     .. versionchanged:: 1.0.0
        Added Windows support if `colorama`_ is installed.
 
-    .. _`colorama`: https://pypi.python.org/pypi/colorama
+    .. _`colorama`: https://pypi.org/pypi/colorama
     """
     _use_color = None
 
@@ -383,7 +383,7 @@ class ColorizedStderrHandler(ColorizingStreamHandlerMixin, StderrHandler):
     .. versionchanged:: 1.0
        Added Windows support if `colorama`_ is installed.
 
-    .. _`colorama`: https://pypi.python.org/pypi/colorama
+    .. _`colorama`: https://pypi.org/pypi/colorama
     """
     def __init__(self, *args, **kwargs):
         StderrHandler.__init__(self, *args, **kwargs)


### PR DESCRIPTION
There is an automatic redirection by pypi.python.org but it would be nicer to link to the final URL.