### PR TITLE
Respect configuration of specific logger when redirecting to std logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ env*
 .vagrant
 flycheck-*
 .idea
+.vscode
 .python-version

--- a/AUTHORS
+++ b/AUTHORS
@@ -17,4 +17,4 @@ Contributors:
 - Raphaël Vinot
 - Rotem Yaari
 - Frazer McLean
-
+- Nguyễn Hồng Quân

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,13 @@
 Logbook Changelog
 =================
 
+Here you can see the full list of changes between each Logbook release.
+
 Version 1.5.0
 -------------
 
 - Added support for asyncio
+- Respect configuration of specific logger in compatibility mode
 
 Version 1.4.3
 -------------
@@ -21,8 +24,6 @@ Released on December 11th, 2018
 - Use correct record delimiters (null for UNIX, newline for network) in SyslogHandler (thanks Jonathan Kamens)
 - Try to reconnect to SyslogHandler TCP sockets when they are disconnected (thanks Jonathan Kamens)
 - Use RFC 5424 format for networking logging in SyslogHandler (thanks Jonathan Kamens)
-
-Here you can see the full list of changes between each Logbook release.
 
 Version 1.4.1
 -------------
@@ -72,7 +73,7 @@ Version 1.0.1
 - Fix PushOver handler cropping (thanks Sébastien Celles)
 
 
-VERSION 1.0.0
+Version 1.0.0
 -------------
 
 Released on June 26th 2016

--- a/logbook/compat.py
+++ b/logbook/compat.py
@@ -172,12 +172,22 @@ class LoggingHandler(logbook.Handler):
         elif isinstance(logger, string_types):
             logger = logging.getLogger(logger)
         self.logger = logger
+        # Cache loggers of specific name
+        self.sublogs = {}
 
     def get_logger(self, record):
         """Returns the logger to use for this record.  This implementation
         always return :attr:`logger`.
         """
-        return self.logger
+        name = record.channel
+        if name == self.logger.name or not name:
+            return self.logger
+        # Look up in cache
+        logger = self.sublogs.get(name)
+        if not logger:
+            logger = logging.getLogger(name)
+            self.sublogs[name] = logger
+        return logger
 
     def convert_level(self, level):
         """Converts a logbook level into a logging level."""


### PR DESCRIPTION
Scenario:
- My project is Django-based. I have 2 place to to consume logs: console and a cloud service.
- I want log messages generated by a module to go to cloud service, not to console, so I configure a dict like this, in Django settings (`LOGGING`):

```py
{
    'root': {
        'handlers': ['console', 'cloud']
    },
    'loggers': {
        'device': {
            'handlers': ['cloud']
        }
    }
}
```
- Then I use `logbook.compat.LoggingHandler` to redirect my messages to standard `logging`.

The issue is that, all messages from `device` goes to console also. This PR is to fix that.

