### PR TITLE
Use collections.abc.Mapping

### DIFF
--- a/logbook/compat.py
+++ b/logbook/compat.py
@@ -133,7 +133,7 @@ class RedirectLoggingHandler(logging.Handler):
         kwargs = None
 
         # Logging allows passing a mapping object, in which case args will be a mapping.
-        if isinstance(args, collections.Mapping):
+        if isinstance(args, collections.abc.Mapping):
             kwargs = args
             args = None
         record = LoggingCompatRecord(old_record.name,


### PR DESCRIPTION
After importing logbook.compat I get the following warning:
```
/opt/venv/lib/python3.7/site-packages/logbook/compat.py:136: DeprecationWarning: Using or
importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated,
and in 3.8 it will stop working
  if isinstance(args, collections.Mapping):
```
This PR simply changes `collections.Mapping` to `collections.abc.Mapping` as recommended by the `DeprecationWarning`.  I believe this change is safe on anything 3.3+, but probably not on 2.7.  Unfortunately Python 3.8 is scheduled for release a few months before support for Python 2.7 ends, so you may want/need to make a final release for 2.7 support before accepting this PR.