### PR TITLE
add url to GitHub for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,10 @@ def run_setup(with_cext):
         name='Logbook',
         version=__version__,
         license='BSD',
-        url='http://logbook.pocoo.org/',
+        url='https://logbook.readthedocs.io/en/stable/',
+        project_urls={
+            'Code': 'https://github.com/getlogbook/logbook',
+        },
         author='Armin Ronacher, Georg Brandl',
         author_email='armin.ronacher@active-4.com',
         description='A logging replacement for Python',

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ def run_setup(with_cext):
         license='BSD',
         url='https://logbook.readthedocs.io/en/stable/',
         project_urls={
-            'Code': 'https://github.com/getlogbook/logbook',
+            'Source': 'https://github.com/getlogbook/logbook',
         },
         author='Armin Ronacher, Georg Brandl',
         author_email='armin.ronacher@active-4.com',


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar on [this screen](https://pypi.org/project/Logbook/), as well as including them in API responses to help automation tool find the source code for Requests. For example, see Django's [setup.cfg](https://github.com/django/django/blob/master/setup.cfg) and [PyPI listing](https://pypi.org/project/Django/).
update docs url