### PR TITLE
Translate exception instance to exc_info

### DIFF
--- a/logbook/base.py
+++ b/logbook/base.py
@@ -468,6 +468,10 @@ class LogRecord(object):
             self.frame = sys._getframe(1)
         if self.exc_info is True:
             self.exc_info = sys.exc_info()
+        if isinstance(self.exc_info, BaseException):
+            self.exc_info = (type(self.exc_info),
+                             self.exc_info,
+                             self.exc_info.__traceback__)
 
     def pull_information(self):
         """A helper function that pulls all frame-related information into

--- a/tests/test_log_record.py
+++ b/tests/test_log_record.py
@@ -19,6 +19,19 @@ def test_exc_info_false():
     assert not record.formatted_exception
 
 
+def test_exc_info_exception_instance(logger):
+    with logbook.handlers.TestHandler() as handler:
+        try:
+            raise ValueError('error here')
+        except Exception as e:
+            error = e
+        logger.exception(exc_info=error)
+    [record] = handler.records
+    assert isinstance(record.exc_info, tuple)
+    assert len(record.exc_info) == 3
+    assert 'Traceback' in record.formatted_exception
+
+
 def test_extradict(active_handler, logger):
     logger.warn('Test warning')
     record = active_handler.records[0]


### PR DESCRIPTION
Logbook expects the `exc_info` property of a `LogRecord` to be either a `bool` or a 3-tuple alike the result of `sys.exc_info()`. Logging an `Exception` instance that's been caught before calling `Logger.exception` is somewhat cumbersome as `sys.exc_info()` will no longer be able to find all the information it would need. The information can be recreated from the `Exception` instance, however, as portrayed by https://bugs.python.org/issue20537.

Having run into this for a library I'm maintaining, this PR aims to mimic the way Python's builtin `logging` deals with this, allowing the `exc_info` parameter to be passed as an `Exception` instance, recreating the 3-tuple used for formatting later on.