### PR TITLE
replace removed SQLAlchemy .count() method

### DIFF
--- a/logbook/ticketing.py
+++ b/logbook/ticketing.py
@@ -243,7 +243,10 @@ class SQLAlchemyBackend(BackendBase):
 
     def count_tickets(self):
         """Returns the number of tickets."""
-        return self.engine.execute(self.tickets.count()).fetchone()[0]
+        from sqlalchemy import select, func
+
+        count_stmt = select([func.count()]).select_from(self.tickets)
+        return self.engine.execute(count_stmt).fetchone()[0]
 
     def get_tickets(self, order_by='-last_occurrence_time', limit=50,
                     offset=0):


### PR DESCRIPTION
.count() was deprecated since SQLAlchemy 1.1 and has recently been removed in 1.4.

https://docs.sqlalchemy.org/en/13/core/selectable.html#sqlalchemy.sql.expression.FromClause.count