### PR TITLE
Fix setuptools warning about "upload-dir"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ build-dir = docs/_build
 all_files = 1
 
 [upload_docs]
-upload-dir = docs/_build/html
+upload_dir = docs/_build/html


### PR DESCRIPTION
Fixes the following warning:
`Usage of dash-separated 'upload-dir' will not be supported in future versions. Please use the underscore name 'upload_dir' instead`