### PR TITLE
Fix group_reflected_property __del__ method instead of __delete__

### DIFF
--- a/src/logbook/_speedups.pyx
+++ b/src/logbook/_speedups.pyx
@@ -62,7 +62,7 @@ cdef class group_reflected_property:
     def __set__(self, obj, value):
         setattr(obj, self._name, value)
 
-    def __del__(self, obj):
+    def __delete__(self, obj):
         delattr(obj, self._name)
 
 

--- a/tests/test_speedups.py
+++ b/tests/test_speedups.py
@@ -1,0 +1,32 @@
+import importlib
+
+import pytest
+
+
+@pytest.fixture(params=["speedups", "fallback"])
+def speedups_module(request):
+    mod_name = f"logbook._{request.param}"
+    try:
+        return importlib.import_module(mod_name)
+    except ImportError:
+        pytest.skip(f"{mod_name} is not available")
+
+
+def test_group_reflected_property(speedups_module):
+    class Group:
+        foo = "group"
+
+    class A:
+        foo = speedups_module.group_reflected_property("foo", "default")
+
+        def __init__(self, group=None):
+            self.group = group
+
+    a = A()
+    assert a.foo == "default"
+    a.group = Group()
+    assert a.foo == "group"
+    a.foo = "set"
+    assert a.foo == "set"
+    del a.foo
+    assert a.foo == "group"


### PR DESCRIPTION
Fixes #336 

This was found because Cython 3 complained about `__del__` having the wrong signature.