### PR TITLE
Fix version attr module path with setuptools static attr parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ nteventlog = ["pywin32; platform_system == 'Windows'"]
 docs = ["Sphinx>=5"]
 
 [tool.setuptools.dynamic]
-version = { attr = "logbook.__version__" }
+version = { attr = "logbook.__version__.__version__" }
 
 [tool.setuptools]
 package-dir = { "" = "src" }


### PR DESCRIPTION
Setuptools attr parser does not support following imports which results in setuptools falling back to dynamically executing the module during a build which can break when runtime dependencies are not yet present.

See:
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#attr

Fixes:
```python
Traceback (most recent call last):
  File "/home/buildroot/buildroot/output/per-package/python-logbook/host/lib/python3.11/site-packages/setuptools/config/expand.py", line 193, in read_attr
    return getattr(StaticModule(module_name, spec), attr_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/buildroot/buildroot/output/per-package/python-logbook/host/lib/python3.11/site-packages/setuptools/config/expand.py", line 87, in __getattr__
    raise AttributeError(f"{self.name} has no attribute {attr}") from e
AttributeError: logbook has no attribute __version__
```