### PR TITLE
Remove unnecessary line in to_safe_json

### DIFF
--- a/src/logbook/helpers.py
+++ b/src/logbook/helpers.py
@@ -136,8 +136,6 @@ def to_safe_json(data):
             for key, value in obj.items():
                 if not isinstance(key, str):
                     key = str(key)
-                if not isinstance(key, str):
-                    key = key
                 rv[key] = _convert(value)
             return rv
 


### PR DESCRIPTION
Removes an unnecessary line of code from the `to_safe_json` function in `src/logbook/helpers.py`.

- Eliminates a redundant check and assignment operation for dictionary keys in the `to_safe_json` function, streamlining the process of making data structures safe for JSON serialization.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getlogbook/logbook?shareId=11afd07f-ba4e-4364-a6ec-0d64e71f0551).