### PR TITLE
Stop swallowing handler errors when errors='raise'

### DIFF
--- a/newsfragments/629.fixed.rst
+++ b/newsfragments/629.fixed.rst
@@ -1,0 +1,4 @@
+An error from a handler now propagates when the ``errors`` flag of
+:class:`~logbook.Flags` is set to ``"raise"``. Logbook previously discarded any
+:exc:`OSError`, which is how most handlers fail, so the logging call returned
+as if the record had been written.

--- a/src/logbook/handlers.py
+++ b/src/logbook/handlers.py
@@ -305,17 +305,17 @@ class Handler(ContextObject, metaclass=_HandlerType):
 
         Check :class:`Flags` for more information.
         """
-        try:
-            behaviour = Flags.get_flag("errors", "print")
-            if behaviour == "raise":
-                raise exc_info[1]
-            elif behaviour == "print":
+        behaviour = Flags.get_flag("errors", "print")
+        if behaviour == "raise":
+            raise exc_info[1]
+        elif behaviour == "print":
+            try:
                 traceback.print_exception(*exc_info, file=sys.stderr)
                 sys.stderr.write(
                     f"Logged from file {record.filename}, line {record.lineno}\n"
                 )
-        except OSError:
-            pass
+            except OSError:
+                pass
 
 
 class NullHandler(Handler):

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,3 +1,7 @@
+import errno
+import os
+import sys
+
 import pytest
 
 import logbook
@@ -30,3 +34,79 @@ def test_disable_introspection(logger):
             assert h.records[0].frame is None
             assert h.records[0].calling_frame is None
             assert h.records[0].module is None
+
+
+def test_file_error_flag_raise(tmp_path, logger, capsys):
+    filename = tmp_path / "missing" / "output.log"
+    with logbook.FileHandler(filename, delay=True), logbook.Flags(errors="raise"):
+        with pytest.raises(FileNotFoundError) as caught:
+            logger.warning("Cannot open the log file")
+
+    assert caught.value.filename == str(filename)
+    assert capsys.readouterr().err == ""
+
+
+def test_file_error_flag_print(tmp_path, logger, capsys):
+    filename = tmp_path / "missing" / "output.log"
+    with logbook.FileHandler(filename, delay=True), logbook.Flags(errors="print"):
+        logger.warning("Cannot open the log file")
+
+    stderr = capsys.readouterr().err
+    assert "FileNotFoundError" in stderr
+    assert "Logged from file" in stderr
+    assert repr(os.fspath(filename)) in stderr
+
+
+def test_file_error_flag_silent(tmp_path, logger, capsys):
+    filename = tmp_path / "missing" / "output.log"
+    with logbook.FileHandler(filename, delay=True), logbook.Flags(errors="silent"):
+        logger.warning("Cannot open the log file")
+
+    assert capsys.readouterr().err == ""
+
+
+class BrokenStderr:
+    """A stderr whose writes fail the way a closed pipe does."""
+
+    def __init__(self, fail_on=None):
+        self.fail_on = fail_on
+        self.attempted = []
+        self.written = []
+
+    def write(self, text):
+        self.attempted.append(text)
+        if self.fail_on is None or text.startswith(self.fail_on):
+            raise OSError(errno.EPIPE, "Broken pipe")
+        self.written.append(text)
+        return len(text)
+
+    def flush(self):
+        pass
+
+
+def test_file_error_flag_print_broken_stderr(tmp_path, logger, monkeypatch):
+    # Reporting the error must not itself raise, or a broken pipe on stderr
+    # turns every log call into a crash.
+    filename = tmp_path / "missing" / "output.log"
+    stderr = BrokenStderr()
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    with logbook.FileHandler(filename, delay=True), logbook.Flags(errors="print"):
+        logger.warning("Cannot open the log file")
+
+    assert stderr.attempted, "the error was never reported to stderr"
+    assert stderr.written == []
+
+
+def test_file_error_flag_print_broken_stderr_trailer(tmp_path, logger, monkeypatch):
+    # The same protection has to cover the trailing line, which is written
+    # separately from the traceback above it.
+    filename = tmp_path / "missing" / "output.log"
+    stderr = BrokenStderr(fail_on="Logged from file")
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    with logbook.FileHandler(filename, delay=True), logbook.Flags(errors="print"):
+        logger.warning("Cannot open the log file")
+
+    assert "FileNotFoundError" in "".join(stderr.written)
+    assert any(text.startswith("Logged from file") for text in stderr.attempted)


### PR DESCRIPTION
handle_error kept the flag check and the stacktrace print in one
try/except OSError. That except is there for the print, but it also
caught the exception handle_error re-raises for 'raise'. Most handler
failures are OSError, so most of them raised nothing.

The except predates the flag. In 2010 it wrapped the print alone, and
the raise landed inside it when the flag stack arrived two months
later. CPython scopes the same suppression to the print, see
python/cpython#50221.
