### PR TITLE
Skip the error report when there is no stderr

### DIFF
--- a/newsfragments/631.fixed.rst
+++ b/newsfragments/631.fixed.rst
@@ -1,0 +1,1 @@
+Handler failures are reported without raising a further error when :data:`sys.stderr` is missing, as it is under ``pythonw``.

--- a/src/logbook/handlers.py
+++ b/src/logbook/handlers.py
@@ -308,7 +308,7 @@ class Handler(ContextObject, metaclass=_HandlerType):
         behaviour = Flags.get_flag("errors", "print")
         if behaviour == "raise":
             raise exc_info[1]
-        elif behaviour == "print":
+        elif behaviour == "print" and sys.stderr:
             try:
                 traceback.print_exception(*exc_info, file=sys.stderr)
                 sys.stderr.write(

--- a/tests/test_handler_errors.py
+++ b/tests/test_handler_errors.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from contextlib import redirect_stderr
 
 import pytest
 
@@ -10,6 +11,30 @@ from .utils import capturing_stderr_context
 __file_without_pyc__ = __file__
 if __file_without_pyc__.endswith(".pyc"):
     __file_without_pyc__ = __file_without_pyc__[:-1]
+
+
+def test_handler_error_without_stderr(logger):
+    with logbook.StderrHandler(), logbook.Flags(errors="print"):
+        with redirect_stderr(None):
+            logger.warning("unavailable stderr")
+
+
+def test_handler_error_without_stderr_under_raise(logger):
+    with logbook.StderrHandler(), logbook.Flags(errors="raise"):
+        with redirect_stderr(None):
+            with pytest.raises(AttributeError):
+                logger.warning("unavailable stderr")
+
+
+def test_handler_error_with_closed_stderr(tmp_path, logger):
+    # A closed stream is truthy, so it passes the guard and its error is left
+    # to the caller, which is what CPython does too.
+    with (tmp_path / "stderr.log").open("w") as stream:
+        pass
+    with logbook.StderrHandler(), logbook.Flags(errors="print"):
+        with redirect_stderr(stream):
+            with pytest.raises(ValueError):
+                logger.warning("unavailable stderr")
 
 
 def test_handler_exception(activation_strategy, logger):


### PR DESCRIPTION
Reporting a handler failure under errors='print' assumed sys.stderr was a stream. Under pythonw it is None, so writing the traceback raised AttributeError out of the error path itself.

CPython guards the same write with "if raiseExceptions and sys.stderr", one line added in python/cpython#58015 for this failure. Do the same. A closed stream is truthy, so it still passes the guard and its error reaches the caller rather than being swallowed.
