### PR TITLE
Re-raise the active exception from Handler.handle_error

### DIFF
--- a/newsfragments/632.deprecated.rst
+++ b/newsfragments/632.deprecated.rst
@@ -1,0 +1,3 @@
+Passing an ``exc_info`` to :meth:`~logbook.Handler.handle_error` that is not
+the exception being handled is deprecated. Report a failure from inside the
+``except`` block that caught it.

--- a/newsfragments/632.fixed.rst
+++ b/newsfragments/632.fixed.rst
@@ -1,0 +1,3 @@
+A handler error re-raised by ``Flags(errors="raise")`` now keeps the traceback
+of the original failure, and no longer strands the failed record in a
+reference cycle.

--- a/src/logbook/handlers.py
+++ b/src/logbook/handlers.py
@@ -304,9 +304,26 @@ class Handler(ContextObject, metaclass=_HandlerType):
         this function depends on the current `errors` setting.
 
         Check :class:`Flags` for more information.
+
+        .. deprecated:: 1.11
+           Passing an ``exc_info`` other than the exception currently being
+           handled.  Report a failure from inside the ``except`` block that
+           caught it.
         """
+        reraise_active = exc_info[1] is sys.exc_info()[1]
+        if not reraise_active:
+            warnings.warn(
+                "Passing an exc_info that is not the active exception to "
+                "handle_error is deprecated. Report the failure from inside "
+                "the except block that caught it.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         behaviour = Flags.get_flag("errors", "print")
         if behaviour == "raise":
+            if reraise_active:
+                raise
             raise exc_info[1]
         elif behaviour == "print" and sys.stderr:
             try:

--- a/tests/test_handler_errors.py
+++ b/tests/test_handler_errors.py
@@ -78,3 +78,57 @@ def test_formatting_exception():
         errormsg,
         re.M | re.S,
     )
+
+
+def test_handle_error_reraises_the_active_exception_untouched(logger, recwarn):
+    class ErroringHandler(logbook.Handler):
+        def emit(self, record):
+            raise OSError(5, "sink down")
+
+    with ErroringHandler(bubble=False), logbook.Flags(errors="raise"):
+        with pytest.raises(OSError) as caught:
+            logger.warning("I warn you.")
+
+    frames = []
+    tb = caught.value.__traceback__
+    while tb is not None:
+        frames.append(tb.tb_frame.f_code.co_name)
+        tb = tb.tb_next
+
+    assert "handle_error" not in frames
+    assert frames[-1] == "emit"
+    assert [w for w in recwarn if w.category is DeprecationWarning] == []
+
+
+def test_handle_error_with_a_stale_exc_info_is_deprecated():
+    record = logbook.LogRecord("Test Logger", logbook.WARNING, "Hello")
+    handler = logbook.Handler()
+
+    try:
+        raise OSError(5, "sink down")
+    except OSError:
+        stale = sys.exc_info()
+
+    with logbook.Flags(errors="silent"):
+        with pytest.deprecated_call(match="not the active exception"):
+            handler.handle_error(record, stale)
+
+
+def test_handle_error_stale_exc_info_wins_over_the_active_exception(logger):
+    class RetryingHandler(logbook.Handler):
+        def emit(self, record):
+            try:
+                raise OSError(28, "disk full")
+            except OSError:
+                original = sys.exc_info()
+            try:
+                raise TimeoutError("retry also failed")
+            except TimeoutError:
+                with pytest.deprecated_call():
+                    self.handle_error(record, original)
+
+    with RetryingHandler(bubble=False), logbook.Flags(errors="raise"):
+        with pytest.raises(OSError) as caught:
+            logger.warning("I warn you.")
+
+    assert caught.value.errno == 28


### PR DESCRIPTION
Raising the exception object spliced `handle_error`'s own frame into the traceback and left the failed record in a cycle with it. A bare raise avoids both, but only suits a caller reporting the failure it is handling, which is all Logbook does.

Reporting a failure captured earlier is now deprecated. CPython's `handleError` reads the active exception itself.

Before, the reporting frame sits between the two halves of `handle`:

```
handle:234 -> handle_error:310 -> handle:232 -> emit -> _open
```

After, the traceback is the one the failure actually produced.