### PR TITLE
Preserve fractional seconds in ISO8601 log record exports

### DIFF
--- a/newsfragments/634.fixed.rst
+++ b/newsfragments/634.fixed.rst
@@ -1,0 +1,1 @@
+Fix ``logbook.helpers.format_iso8601()`` to zero-pad microseconds to six digits, preserving timestamp precision in its output and JSON-safe log record exports.

--- a/src/logbook/helpers.py
+++ b/src/logbook/helpers.py
@@ -174,7 +174,7 @@ def format_iso8601(d=None):
         d = datetime_utcnow()
     rv = d.strftime("%Y-%m-%dT%H:%M:%S")
     if d.microsecond:
-        rv += "." + str(d.microsecond)
+        rv += f".{d.microsecond:06d}"
     return rv + "Z"
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -48,3 +48,18 @@ def test_datehelpers():
     assert v.hour == 11
     v = parse_iso8601("2000-01-01T12:00:00-01:00")
     assert v.hour == 13
+
+
+@pytest.mark.parametrize("microsecond", [1, 12, 123, 1234, 12345, 123456, 0])
+def test_iso8601_preserves_fractional_seconds(microsecond):
+    from logbook.helpers import format_iso8601, parse_iso8601
+
+    timestamp = datetime(2000, 1, 1, microsecond=microsecond)
+
+    formatted = format_iso8601(timestamp)
+
+    assert parse_iso8601(formatted) == timestamp
+    assert (
+        datetime.fromisoformat(formatted.replace("Z", "+00:00")).replace(tzinfo=None)
+        == timestamp
+    )


### PR DESCRIPTION
format_iso8601() renders microsecond=1 as .1, which represents 100000 microseconds. Pad the fractional part to six digits so JSON-safe LogRecord exports survive an exact timestamp round trip. Seven regression cases include zero and six-digit fractions.

Validation: Original regression: five parameter cases failed against the unmodified implementation (1/12/123/1234/12345 microseconds); see logbook-red.log. Full suite: 260 passed, 38 skipped in 5.10s (logbook-green.log). Final formatted test rerun: 9 passed. Ruff check and Ruff format checks passed on both changed files.

Manual QA: PASS: six LogRecord JSON export/import timestamps preserve exact microseconds

Limitations: macOS CPython 3.14.6, pure Python fallback; 38 optional/backend tests skipped; native Rust backend and other Python versions were not tested.

AI disclosure: OpenAI Codex generated and locally tested this patch and regression tests.
